### PR TITLE
Add test to ensure user id claim in JWT token

### DIFF
--- a/DotNet8.ScalarWebApi.Tests/AuthServiceTests.cs
+++ b/DotNet8.ScalarWebApi.Tests/AuthServiceTests.cs
@@ -1,0 +1,67 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using DotNet8.WebApi.Data;
+using DotNet8.WebApi.Dtos;
+using DotNet8.WebApi.Entities;
+using DotNet8.WebApi.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
+namespace DotNet8.ScalarWebApi.Tests
+{
+    public class AuthServiceTests
+    {
+        [Fact]
+        public async Task LoginAsync_ShouldIncludeUserIdClaim()
+        {
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            await using var context = new AppDbContext(options);
+
+            var user = new User
+            {
+                Username = "testuser",
+                Email = "test@example.com"
+            };
+
+            user.HashedPassword = new PasswordHasher<User>()
+                .HashPassword(user, "P@ssw0rd!");
+
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var inMemorySettings = new Dictionary<string, string?>
+            {
+                {"AppSettings:Token", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+                {"AppSettings:Issuer", "TestIssuer"},
+                {"AppSettings:Audience", "TestAudience"}
+            };
+
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(inMemorySettings)
+                .Build();
+
+            var authService = new AuthService(context, configuration);
+            var loginRequest = new UserDto
+            {
+                Username = user.Username,
+                Password = "P@ssw0rd!"
+            };
+
+            var token = await authService.LoginAsync(loginRequest);
+
+            Assert.NotNull(token);
+
+            var handler = new JwtSecurityTokenHandler();
+            var jwt = handler.ReadJwtToken(token);
+
+            var idClaim = jwt.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier);
+
+            Assert.NotNull(idClaim);
+            Assert.Equal(user.Id.ToString(), idClaim!.Value);
+        }
+    }
+}

--- a/DotNet8.ScalarWebApi.Tests/DotNet8.ScalarWebApi.Tests.csproj
+++ b/DotNet8.ScalarWebApi.Tests/DotNet8.ScalarWebApi.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotNet8.ScalarWebApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DotNet8.ScalarWebApi.Tests/GlobalUsings.cs
+++ b/DotNet8.ScalarWebApi.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/DotNet8.ScalarWebApi.csproj
+++ b/DotNet8.ScalarWebApi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -7,6 +7,12 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <RootNamespace>DotNet8.WebApi</RootNamespace>
     </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Remove="DotNet8.ScalarWebApi.Tests\**\*.cs" />
+        <EmbeddedResource Remove="DotNet8.ScalarWebApi.Tests\**\*" />
+        <None Remove="DotNet8.ScalarWebApi.Tests\**\*" />
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.19" />

--- a/DotNet8.ScalarWebApi.sln
+++ b/DotNet8.ScalarWebApi.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.12.35527.113 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNet8.ScalarWebApi", "DotNet8.ScalarWebApi.csproj", "{59D3BCAD-8892-4550-8207-65990BC6C4D5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNet8.ScalarWebApi.Tests", "DotNet8.ScalarWebApi.Tests\DotNet8.ScalarWebApi.Tests.csproj", "{C6879198-255C-4B12-A889-622FF784AF4E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{59D3BCAD-8892-4550-8207-65990BC6C4D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{59D3BCAD-8892-4550-8207-65990BC6C4D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{59D3BCAD-8892-4550-8207-65990BC6C4D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6879198-255C-4B12-A889-622FF784AF4E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6879198-255C-4B12-A889-622FF784AF4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6879198-255C-4B12-A889-622FF784AF4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6879198-255C-4B12-A889-622FF784AF4E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add an xUnit test project that exercises `AuthService.LoginAsync` and verifies the generated JWT contains the user id claim
- exclude the test project files from the main web API project build and add the new project to the solution

## Testing
- dotnet test


------
https://chatgpt.com/codex/tasks/task_e_68d2bc13427c83268acc48bffc765a97